### PR TITLE
master

### DIFF
--- a/src/io/cmdline.cpp
+++ b/src/io/cmdline.cpp
@@ -676,17 +676,20 @@ bool parse_cmd_line(int argc, char **argv)
 			get_next_word(s, sizeof(s)); 
 			change_dir(s);
 		}
+
+		//joynum defines the joystick number -joynum 0 means /dev/input/js0  -joynum 1 means /dev/input/js1
+		//the default is /dev/input/js0
 		else if (strcasecmp(s, "-joynum")==0)
 		{
 			get_next_word(s, sizeof(s));
 
 			int joynum = atoi(s);
 			set_joy_num(joynum);
-            sprintf(s, "Using joystick %d", joynum);
-            printline(s);
+			sprintf(s, "Using joystick %d", joynum);
+			printline(s);
 		}
 
-			// if user wants laserdisc player to blank video while searching (VLDP only)
+		// if user wants laserdisc player to blank video while searching (VLDP only)
 		else if (strcasecmp(s, "-blank_searches")==0)
 		{
 			g_ldp->set_search_blanking(true);

--- a/src/io/cmdline.cpp
+++ b/src/io/cmdline.cpp
@@ -676,8 +676,17 @@ bool parse_cmd_line(int argc, char **argv)
 			get_next_word(s, sizeof(s)); 
 			change_dir(s);
 		}
+		else if (strcasecmp(s, "-joynum")==0)
+		{
+			get_next_word(s, sizeof(s));
 
-		// if user wants laserdisc player to blank video while searching (VLDP only)
+			int joynum = atoi(s);
+			set_joy_num(joynum);
+            sprintf(s, "Using joystick %d", joynum);
+            printline(s);
+		}
+
+			// if user wants laserdisc player to blank video while searching (VLDP only)
 		else if (strcasecmp(s, "-blank_searches")==0)
 		{
 			g_ldp->set_search_blanking(true);

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -55,6 +55,7 @@ bool g_use_joystick = true;	// use a joystick by default
 bool g_consoledown = false;			// whether the console is down or not
 bool g_alt_pressed = false;	// whether the ALT key is presssed (for ALT-Enter combo)
 unsigned int idle_timer; // added by JFA for -idleexit
+int g_joy_num = 0;
 
 const double STICKY_COIN_SECONDS = 0.125;	// how many seconds a coin acceptor is forced to be "depressed" and how many seconds it is forced to be "released"
 Uint32 g_sticky_coin_cycles = 0;	// STICKY_COIN_SECONDS * get_cpu_hz(0), cannot be calculated statically
@@ -282,10 +283,14 @@ int SDL_input_init()
 			// if there is at least 1 joystick and we are authorized to use the joystick for input
 			if (SDL_NumJoysticks() > 0)
 			{
-				G_joystick = SDL_JoystickOpen(0);	// FIXME: right now we automatically choose the first joystick
+                char str[40];
+                sprintf(str, "NumSticks %d", SDL_NumJoysticks());
+                printline(str);
+                G_joystick = SDL_JoystickOpen(g_joy_num);
 				if (G_joystick != NULL)
 				{
-					printline("Joystick #0 was successfully opened");
+					sprintf(str, "Joystick  %d was successfully opened", g_joy_num);
+					printline(str);
 				}
 				else
 				{
@@ -852,4 +857,8 @@ void reset_idle(void)
 void set_use_joystick(bool val)
 {
 	g_use_joystick = val;
+}
+
+void set_joy_num(int num) {
+	g_joy_num = num;
 }

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -283,10 +283,10 @@ int SDL_input_init()
 			// if there is at least 1 joystick and we are authorized to use the joystick for input
 			if (SDL_NumJoysticks() > 0)
 			{
-                char str[40];
-                sprintf(str, "NumSticks %d", SDL_NumJoysticks());
-                printline(str);
-                G_joystick = SDL_JoystickOpen(g_joy_num);
+				char str[40];
+				sprintf(str, "NumSticks %d", SDL_NumJoysticks());
+				printline(str);
+				G_joystick = SDL_JoystickOpen(g_joy_num);
 				if (G_joystick != NULL)
 				{
 					sprintf(str, "Joystick  %d was successfully opened", g_joy_num);

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -91,6 +91,7 @@ void input_disable(Uint8);
 inline void add_coin_to_queue(bool enabled, Uint8 val);
 void reset_idle(void); // added by JFA
 void set_use_joystick(bool val);
+void set_joy_num(int num);
 
 #endif // INPUT_H
 


### PR DESCRIPTION
Adding -joynum parameter which allows to set the daphne 
default joystick to another value than /dev/input/js0

usage -joynum 1 sets the joystick to /dev/input/js1